### PR TITLE
When a codemod had no presets it would print 'undefined'. now it doesnt

### DIFF
--- a/scripts/docs.ts
+++ b/scripts/docs.ts
@@ -81,8 +81,9 @@ $ codeshift-cli --packages ${name}@${key} path/to/source
   )
   .join('')}
 
-${config.presets &&
-  `
+${
+  config.presets
+    ? `
 ## Presets
 
 ${Object.keys(config.presets)
@@ -99,7 +100,9 @@ $ codeshift-cli --packages ${name}#${key} path/to/source
 `,
   )
   .join('')}
-`}
+`
+    : ''
+}
 `,
     );
   });


### PR DESCRIPTION
Before:

<img width="991" alt="Screen Shot 2021-10-26 at 10 18 05 am" src="https://user-images.githubusercontent.com/2182637/138783610-e794ba8f-600f-467e-b101-496af0484054.png">

After:

<img width="895" alt="Screen Shot 2021-10-26 at 10 19 00 am" src="https://user-images.githubusercontent.com/2182637/138783710-6bd14ba4-50bd-409e-8bbe-6f2eb620f360.png">


