### PR TITLE
feat: temp `run.js` script to quickly run local codemods

### DIFF
--- a/run.js
+++ b/run.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+/**
+ * a temporary utility to run local codemods quickly
+ * before we improve stuff upstream.
+ */
+
+const helpMsg = `
+run.js parser=flow codemodsToRun filesOrDirectoriesToModify extensions="js,jsx,ts,tsx"
+
+codemodsToRun - paths to codemods which have a codeshift.config.js file.
+                separated by spaces.
+                can also just provide keys from the "shorthands.json" file
+
+examples:
+
+./run.js flow ./community/@pipedrive__convention-ui-react/src/5.0.0/transform.ts ~/projects/some-project-which-uses-cui4/src/
+./run.js flow cui5                                                               ~/projects/some-project-which-uses-cui4/src/ # cui5 is from shorthands.json
+
+`;
+
+const path = require('path');
+const cp = require('child_process');
+
+const peekNextArg = () => process.argv[0];
+const eatNextArg = () => process.argv.shift();
+
+const shouldPrintHelp = () => (
+  (should =
+    !process.argv.length ||
+    ['-h', '--help', '-help', 'help'].includes(peekNextArg())),
+  should && console.log(helpMsg),
+  should
+);
+
+const parseArgv = () => (
+  process.argv.splice(0, 2),
+  shouldPrintHelp() && process.exit(1),
+  {
+    parser: eatNextArg() || 'flow',
+    transformsToRun: eatNextArg() || '',
+    filesOrDirectoriesToModify: eatNextArg() || '',
+    extensions: eatNextArg() || 'js,jsx,ts,tsx',
+  }
+);
+
+run();
+
+function run() {
+  let {
+    parser, //
+    transformsToRun,
+    filesOrDirectoriesToModify,
+    extensions,
+  } = parseArgv();
+
+  const shorthands = require(path.join(__dirname, './shorthands.json'));
+  console.log({ shorthands });
+
+  transformsToRun = parseArrayFromCsv(transformsToRun)
+    .map(t => {
+      if (t in shorthands) {
+        return resolveTransformsFromShorthand(shorthands[t]);
+      } else {
+        const dir = path.dirname(t);
+        const cmd = `yarn --cwd ${dir} build`;
+        console.log('transform to run, build cmd', { cmd });
+        cp.execSync(cmd);
+        return t;
+      }
+    })
+    .flat();
+
+  filesOrDirectoriesToModify = parseArrayFromCsv(filesOrDirectoriesToModify);
+
+  const cliPath = path.join(__dirname, './packages/cli/bin/codeshift-cli.js');
+
+  const cmdToExec = `${cliPath} --parser ${parser} -e ${extensions} -t ${transformsToRun} ${filesOrDirectoriesToModify}`;
+  console.log({ cmdToExec });
+
+  cp.exec(cmdToExec, (err, stdout, stderr) => {
+    if (err) {
+      console.error(stderr);
+      return process.exit(1);
+    }
+
+    console.log(stdout);
+
+    console.log('succ');
+    process.exit(0);
+  });
+}
+
+function parseArrayFromCsv(csv = '') {
+  return csv
+    .split(',')
+    .filter(c => !!c)
+    .map(c => c.trim())
+    .filter(c => !!c);
+}
+
+function resolveTransformsFromShorthand([pathToCodemodPkg, transformVersion]) {
+  cp.execSync(`yarn --cwd ${pathToCodemodPkg} build`);
+  console.log('built');
+
+  const pathToCodemodConfig = path.join(
+    pathToCodemodPkg,
+    'dist',
+    'codeshift.config.js',
+  );
+  console.log({ pathToCodemodConfig });
+
+  const codemodCfg = require(path.join(__dirname, pathToCodemodConfig));
+
+  const { transforms } = codemodCfg;
+
+  const transformsApplicable = Object.entries(transforms)
+    .map(([version, relPathToTransform]) => {
+      if (version === transformVersion) {
+        return relPathToTransform;
+        // return path.join(pathToCodemodPkg, 'dist', relPathToTransform); // TODO must ensure it's compiled / run with ts-node / require from 'dist'
+      }
+    })
+    .filter(x => !!x);
+
+  return transformsApplicable;
+}

--- a/run.js
+++ b/run.js
@@ -69,7 +69,8 @@ function run() {
         return t;
       }
     })
-    .flat();
+    .flat()
+    .join(',');
 
   const cliPath = path.join(__dirname, './packages/cli/bin/codeshift-cli.js');
 

--- a/run.js
+++ b/run.js
@@ -6,7 +6,7 @@
  */
 
 const helpMsg = `
-run.js parser=flow codemodsToRun filesOrDirectoriesToModify extensions="js,jsx,ts,tsx"
+run.js parser=flow codemodsToRun fileOrDirectoryToModify extensions="js,jsx,ts,tsx"
 
 codemodsToRun - paths to codemods which have a codeshift.config.js file.
                 separated by spaces.
@@ -38,8 +38,8 @@ const parseArgv = () => (
   shouldPrintHelp() && process.exit(1),
   {
     parser: eatNextArg() || 'flow',
-    transformsToRun: eatNextArg() || '',
-    filesOrDirectoriesToModify: eatNextArg() || '',
+    transformsToRun: parseArrayFromCsv(eatNextArg() || ''),
+    fileOrDirectoryToModify: eatNextArg() || '',
     extensions: eatNextArg() || 'js,jsx,ts,tsx',
   }
 );
@@ -50,14 +50,14 @@ function run() {
   let {
     parser, //
     transformsToRun,
-    filesOrDirectoriesToModify,
+    fileOrDirectoryToModify,
     extensions,
   } = parseArgv();
 
   const shorthands = require(path.join(__dirname, './shorthands.json'));
   console.log({ shorthands });
 
-  transformsToRun = parseArrayFromCsv(transformsToRun)
+  transformsToRun = transformsToRun
     .map(t => {
       if (t in shorthands) {
         return resolveTransformsFromShorthand(shorthands[t]);
@@ -71,11 +71,9 @@ function run() {
     })
     .flat();
 
-  filesOrDirectoriesToModify = parseArrayFromCsv(filesOrDirectoriesToModify);
-
   const cliPath = path.join(__dirname, './packages/cli/bin/codeshift-cli.js');
 
-  const cmdToExec = `${cliPath} --parser ${parser} -e ${extensions} -t ${transformsToRun} ${filesOrDirectoriesToModify}`;
+  const cmdToExec = `${cliPath} --parser ${parser} -e ${extensions} -t ${transformsToRun} ${fileOrDirectoryToModify}`;
   console.log({ cmdToExec });
 
   cp.exec(cmdToExec, (err, stdout, stderr) => {

--- a/shorthands.json
+++ b/shorthands.json
@@ -1,0 +1,3 @@
+{
+  "cui5": ["./community/@pipedrive__convention-ui-react", "5.0.0"]
+}


### PR DESCRIPTION
see how to test:
https://github.com/pipedrive/CodeshiftCommunity/pull/3

depends on: https://github.com/CodeshiftCommunity/CodeshiftCommunity/pull/63, but in our fork we have it already included in the PR so if you're following the above instructions it's already included.

note - this script kinda hacky, and I'm creating this here not to merge but to show the use-case. (that's why marked as draft).
this also showcases why i needed https://github.com/CodeshiftCommunity/CodeshiftCommunity/pull/64.

ideally this functionaly / ease-of-use would end-up in the `codeshift-cli` itself. perhaps after https://github.com/CodeshiftCommunity/CodeshiftCommunity/pull/58 is done to avoid conflicts:D

thought not sure about the `shorthands.json` - kinda hides what's actually going on, and i think making the consumer more aware would actually be a benefit.

another note - didn't test this w/ existing "reduced" codemods - would likely need to update a few places where logic w/ paths / file structure exists.

---

also depends on: https://github.com/CodeshiftCommunity/CodeshiftCommunity/pull/66