### PR TITLE
removes redundant deps

### DIFF
--- a/.changeset/long-onions-begin.md
+++ b/.changeset/long-onions-begin.md
@@ -1,0 +1,5 @@
+---
+'@hypermod/fetcher': minor
+---
+
+Added blacklist to remote package fetcher to ensure dependencies such as `javascript` aren't downloaded since they will never contain a hypermod.config file.

--- a/.changeset/tidy-seals-glow.md
+++ b/.changeset/tidy-seals-glow.md
@@ -1,0 +1,7 @@
+---
+'@hypermod/initializer': patch
+'@hypermod/validator': patch
+'@hypermod/fetcher': patch
+---
+
+Removes unused dependencies

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -11,8 +11,7 @@
     "chalk": "^4.1.0",
     "fs-extra": "^9.1.0",
     "globby": "^11.1.0",
-    "live-plugin-manager": "^0.18.1",
-    "ts-node": "^10.9.1"
+    "live-plugin-manager": "^0.18.1"
   },
   "engines": {
     "node": ">=14"

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -95,6 +95,10 @@ export async function fetchRemotePackage(
   packageName: string,
   packageManager: PluginManager,
 ): Promise<ConfigMeta> {
+  if (['javascript', 'typescript'].includes(packageName)) {
+    throw new Error(`'${packageName}' is ignored as a remote package.`);
+  }
+
   await packageManager.install(packageName);
   const info = packageManager.getInfo(packageName);
 

--- a/packages/initializer/package.json
+++ b/packages/initializer/package.json
@@ -11,8 +11,7 @@
     "@hypermod/utils": "*",
     "fs-extra": "^9.1.0",
     "recast": "^0.20.4",
-    "semver": "^7.3.5",
-    "ts-node": "^10.9.1"
+    "semver": "^7.3.5"
   },
   "engines": {
     "node": ">=14"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -9,11 +9,7 @@
   "dependencies": {
     "@hypermod/fetcher": "^0.4.1",
     "@hypermod/types": "^0.1.0",
-    "fs-extra": "^9.1.0",
-    "lodash": "^4.17.21",
-    "recast": "^0.20.4",
-    "semver": "^7.3.5",
-    "ts-node": "^10.9.1"
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.176"


### PR DESCRIPTION
- removes redundant deps
- Added blacklist to remote package fetcher to ensure dependencies such as `javascript` aren't downloaded since they will never contain a hypermod.config file.