### PR TITLE
Bumps jscodeshift globally

### DIFF
--- a/.changeset/afraid-ligers-tap.md
+++ b/.changeset/afraid-ligers-tap.md
@@ -1,0 +1,8 @@
+---
+'@hypermod/initializer': minor
+'@hypermod/utils': minor
+'@hypermod/core': minor
+'@hypermod/cli': minor
+---
+
+Bumps jscodeshift to the latest version to surface bug fixes and various improvements. Note: this may inherently change how files are parsed and transformed.

--- a/.changeset/smart-teachers-report.md
+++ b/.changeset/smart-teachers-report.md
@@ -1,0 +1,27 @@
+---
+'@hypermod/mod-atlaskit__progress-indicator': minor
+'@hypermod/mod-atlaskit__section-message': minor
+'@hypermod/mod-atlaskit__side-navigation': minor
+'@hypermod/mod-atlaskit__breadcrumbs': minor
+'@hypermod/mod-atlaskit__textfield': minor
+'@hypermod/mod-atlaskit__calendar': minor
+'@hypermod/mod-atlaskit__checkbox': minor
+'@hypermod/mod-atlaskit__textarea': minor
+'@hypermod/mod-atlaskit__spinner': minor
+'@hypermod/mod-emotion__monorepo': minor
+'@hypermod/mod-atlaskit__avatar': minor
+'@hypermod/mod-atlaskit__button': minor
+'@hypermod/mod-atlaskit__popper': minor
+'@hypermod/mod-atlaskit__toggle': minor
+'@hypermod/mod-atlaskit__popup': minor
+'@hypermod/mod-atlaskit__range': minor
+'@hypermod/mod-atlaskit__icon': minor
+'@hypermod/mod-atlaskit__menu': minor
+'@hypermod/mod-atlaskit__tag': minor
+'@hypermod/mod-memoize-one': minor
+'@hypermod/mod-javascript': minor
+'@hypermod/mod-hypermod': minor
+'@hypermod/mod-react': minor
+---
+
+Bumps jscodeshift, which may have unintended side-effects

--- a/community/@atlaskit__avatar/package.json
+++ b/community/@atlaskit__avatar/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__avatar/src/18.0.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__avatar/src/18.0.0/__tests__/transform.spec.ts
@@ -142,7 +142,7 @@ describe('Update Avatar props', () => {
         import Avatar from '@atlaskit/avatar';
 
         const App = () => {
-          return <Avatar />;
+          return (<Avatar />);
         }
       `,
     'should remove all deleted props',
@@ -170,7 +170,7 @@ describe('Update Avatar props', () => {
         import Foo from '@atlaskit/avatar';
 
         const App = () => {
-          return <Foo />;
+          return (<Foo />);
         }
       `,
     'should remove all deleted props with aliased import name',
@@ -194,7 +194,7 @@ describe('Update Avatar props', () => {
         import Avatar from '@atlaskit/avatar';
 
         const App = () => {
-          return <Avatar />;
+          return (<Avatar />);
         }
       `,
     'should remove enableTooltip when false',
@@ -256,7 +256,7 @@ describe('Update AvatarItem props', () => {
         import Avatar, { AvatarItem } from '@atlaskit/avatar';
 
         const App = () => {
-          return <AvatarItem />;
+          return (<AvatarItem />);
         }
       `,
     'should remove all deleted props',
@@ -284,7 +284,7 @@ describe('Update AvatarItem props', () => {
       import { AvatarItem as Foo } from '@atlaskit/avatar';
 
       const App = () => {
-        return <Foo />;
+        return (<Foo />);
       }
     `,
     'should remove all deleted props with aliased import',
@@ -308,7 +308,7 @@ describe('Update AvatarItem props', () => {
     import { AvatarItem } from '@atlaskit/avatar';
 
     const App = () => {
-      return <AvatarItem />;
+      return (<AvatarItem />);
     }
   `,
     'should remove enableTextTruncate when defaulted to true',
@@ -333,9 +333,9 @@ describe('Update AvatarItem props', () => {
 
       const App = () => {
         return (
-          <AvatarItem
+          (<AvatarItem
             isTruncationDisabled
-          />
+          />)
         );
       }
     `,
@@ -365,9 +365,9 @@ describe('Update AvatarItem props', () => {
 
       const App = () => {
         return (
-          <AvatarItem
+          (<AvatarItem
             isTruncationDisabled={!value}
-          />
+          />)
         );
       }
     `,
@@ -399,9 +399,9 @@ describe('Update AvatarItem props', () => {
 
       const App = () => {
         return (
-          <AvatarItem
+          (<AvatarItem
             isTruncationDisabled={!(foo && bar)}
-          />
+          />)
         );
       }
     `,
@@ -426,7 +426,7 @@ describe('Update AvatarItem props', () => {
       import Avatar, { AvatarItem } from '@atlaskit/avatar';
 
       const App = () => {
-        return <AvatarItem />;
+        return (<AvatarItem />);
       }
     `,
     'should remove isTruncationDisabled when true',

--- a/community/@atlaskit__breadcrumbs/package.json
+++ b/community/@atlaskit__breadcrumbs/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__button/package.json
+++ b/community/@atlaskit__button/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__calendar/package.json
+++ b/community/@atlaskit__calendar/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__calendar/src/11.0.0/__tests__/flatten-certain-inner-props.spec.ts
+++ b/community/@atlaskit__calendar/src/11.0.0/__tests__/flatten-certain-inner-props.spec.ts
@@ -46,7 +46,7 @@ describe('Flatten Inner Prop Style As Prop', () => {
             import Calendar from '@atlaskit/calendar';
             const SimpleCalendar = () => {
               return (
-                <Calendar
+                (<Calendar
                   innerProps={{
                     style: {
                       border: '1px solid red',
@@ -58,7 +58,7 @@ describe('Flatten Inner Prop Style As Prop', () => {
                     border: '1px solid red',
                     display: 'inline-block',
                   }}
-                  className={'abc'} />
+                  className={'abc'} />)
               );
             };"
     `);
@@ -89,11 +89,11 @@ describe('Flatten Inner Prop Style As Prop', () => {
             import Calendar from '@atlaskit/calendar';
             const SimpleCalendar = () => {
               return (
-                <Calendar
+                (<Calendar
                   innerProps={{
                     className: 'abc',
                   }}
-                  className={'abc'} />
+                  className={'abc'} />)
               );
             };"
     `);
@@ -127,7 +127,7 @@ describe('Flatten Inner Prop Style As Prop', () => {
             import Calendar from '@atlaskit/calendar';
             const SimpleCalendar = () => {
               return (
-                <Calendar
+                (<Calendar
                   innerProps={{
                     style: {
                       border: '1px solid red',
@@ -137,7 +137,7 @@ describe('Flatten Inner Prop Style As Prop', () => {
                   style={{
                     border: '1px solid red',
                     display: 'inline-block',
-                  }} />
+                  }} />)
               );
             };"
     `);

--- a/community/@atlaskit__calendar/src/11.0.0/__tests__/remove-inner-props.spec.ts
+++ b/community/@atlaskit__calendar/src/11.0.0/__tests__/remove-inner-props.spec.ts
@@ -51,7 +51,7 @@ describe('Remove innerProps', () => {
             import Calendar from '@atlaskit/calendar';
 
             const SimpleCalendar = () => {
-              return <Calendar />;
+              return (<Calendar />);
             }"
     `);
   });
@@ -91,7 +91,7 @@ describe('Remove innerProps', () => {
             import AkCalendar from '@atlaskit/calendar';
 
             const SimpleCalendar = () => {
-              return <AkCalendar />;
+              return (<AkCalendar />);
             }"
     `);
   });
@@ -135,10 +135,10 @@ describe('Remove innerProps', () => {
 
             const SimpleCalendar = () => {
               return (
-                <Calendar
+                (<Calendar
                   defaultDisabled={['2020-12-04']}
                   defaultPreviouslySelected={['2020-12-06']}
-                  defaultSelected={['2020-12-08']} />
+                  defaultSelected={['2020-12-08']} />)
               );
             }"
     `);

--- a/community/@atlaskit__calendar/src/11.0.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__calendar/src/11.0.0/__tests__/transform.spec.ts
@@ -46,7 +46,7 @@ describe('@atlaskit/calendar@11.0.0 transform', () => {
 
           const SimpleCalendar= () => {
             return (
-              <Calendar
+              (<Calendar
                 defaultDisabled={['2020-12-04']}
                 defaultPreviouslySelected={['2020-12-06']}
                 defaultSelected={['2020-12-08']}
@@ -57,7 +57,7 @@ describe('@atlaskit/calendar@11.0.0 transform', () => {
                 style={{
                   border: '1px solid red',
                   display: 'inline-block',
-                }} />
+                }} />)
             );
           }"
     `);
@@ -107,7 +107,7 @@ describe('@atlaskit/calendar@11.0.0 transform', () => {
 
           const SimpleCalendar= () => {
             return (
-              <Calendar
+              (<Calendar
                 defaultDisabled={['2020-12-04']}
                 defaultPreviouslySelected={['2020-12-06']}
                 defaultSelected={['2020-12-08']}
@@ -118,7 +118,7 @@ describe('@atlaskit/calendar@11.0.0 transform', () => {
                 style={{
                   border: '1px solid red',
                   display: 'inline-block',
-                }} />
+                }} />)
             );
           }"
     `);
@@ -161,13 +161,13 @@ describe('@atlaskit/calendar@11.0.0 transform', () => {
             import Calendar from '@atlaskit/calendar';
             const SimpleCalendar= () => {
               return (
-                <Calendar
+                (<Calendar
                   defaultDisabled={['2020-12-04']}
                   defaultPreviouslySelected={['2020-12-06']}
                   defaultSelected={['2020-12-08']}
                   defaultMonth={12}
                   defaultYear={2020}
-                  testId="the-calendar" />
+                  testId="the-calendar" />)
               );
             }"
     `);

--- a/community/@atlaskit__checkbox/package.json
+++ b/community/@atlaskit__checkbox/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__checkbox/src/12.0.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__checkbox/src/12.0.0/__tests__/transform.spec.ts
@@ -229,11 +229,11 @@ describe('Update ref prop', () => {
                 let ref = useRef();
 
                 return (
-                  <Checkbox
+                  (<Checkbox
                     ref={newRef => {
                       ref = newRef;
                     }}
-                  />
+                  />)
                 );
               }"
     `);
@@ -345,7 +345,7 @@ describe('Remove props', () => {
               import Icon from '@atlaskit/icon/glyph/check-circle';
 
               const SimpleCheckbox = () => {
-                return <Checkbox />;
+                return (<Checkbox />);
               }"
     `);
   });
@@ -381,7 +381,7 @@ describe('Remove props', () => {
               import customeTheme from './theme';
 
               const SimpleCheckbox = () => {
-                return <Checkbox />;
+                return (<Checkbox />);
               }"
     `);
   });
@@ -437,7 +437,7 @@ describe('Remove props', () => {
               import customeTheme from './theme';
 
               const SimpleCheckbox = () => {
-                return <Checkbox />;
+                return (<Checkbox />);
               }"
     `);
   });
@@ -498,7 +498,7 @@ describe('Remove props', () => {
                   import customeTheme from './theme';
 
                   const SimpleCheckbox = () => {
-                    return <Checkbox />;
+                    return (<Checkbox />);
                   }"
     `);
   });
@@ -536,11 +536,11 @@ describe('Remove props', () => {
       of the checkbox there is now a \`size\` prop. The appearance of Checkbox
       will have likely changed. */ import React from 'react'; import { Checkbox
       } from "@atlaskit/checkbox"; import customeTheme from './theme'; const
-      SimpleCheckbox = () => { return (
+      SimpleCheckbox = () => { return ( (
       <div>
         <Checkbox />
         <Checkbox />
-      </div>); }
+      </div>) ); }
     `);
   });
   it('should remove props when using an aliased name', async () => {
@@ -595,7 +595,7 @@ describe('Remove props', () => {
               import customeTheme from './theme';
 
               const SimpleCheckbox = () => {
-                return <Foo />;
+                return (<Foo />);
               }"
     `);
   });

--- a/community/@atlaskit__icon/package.json
+++ b/community/@atlaskit__icon/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__menu/package.json
+++ b/community/@atlaskit__menu/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__menu/src/0.7.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__menu/src/0.7.0/__tests__/transform.spec.ts
@@ -39,11 +39,7 @@ describe('@atlaskit/menu@0.7.0 transform', () => {
       import { ButtonItem } from '@atlaskit/menu';
 
       const App = () => {
-        return (
-          <ButtonItem cssFn={state => {
-
-          }} />
-        );
+        return <ButtonItem cssFn={state => ({})} />;
       }
   `,
     'should remove current styles from inline function',
@@ -57,14 +53,8 @@ describe('@atlaskit/menu@0.7.0 transform', () => {
 
       const App = () => {
         return (
-          <div cssFn={(styles, state) => ({
-            ...styles,
-          })}>
-            <ButtonItem
-              cssFn={(styles, state) => ({
-                ...styles,
-              })}
-            />
+          <div cssFn={(styles, state) => ({ ...styles })}>
+            <ButtonItem cssFn={(styles, state) => ({ ...styles })} />
           </div>
         );
       };
@@ -75,13 +65,9 @@ describe('@atlaskit/menu@0.7.0 transform', () => {
 
       const App = () => {
         return (
-          <div cssFn={(styles, state) => ({
-            ...styles,
-          })}>
-            <ButtonItem
-              cssFn={state => ({})}
-            />
-          </div>
+          (<div cssFn={(styles, state) => ({ ...styles })}>
+            <ButtonItem cssFn={state => ({})} />
+          </div>)
         );
       };
   `,
@@ -170,7 +156,7 @@ describe('@atlaskit/menu@0.7.0 transform', () => {
 
     const App = () => {
       return (
-        <ButtonItem
+        (<ButtonItem
           /*
           TODO: (@hypermod) The usage of the 'cssFn' prop in this component could not be transformed and requires manual intervention.
           The 'cssFn' prop has been simplified so that users no longer need to merge the inherited styles with their own overrides.
@@ -179,7 +165,7 @@ describe('@atlaskit/menu@0.7.0 transform', () => {
           cssFn={(styles, state) => ({
             ...(state.x ? styles : {}),
             color: 'red'
-          })} />
+          })} />)
       );
     }
       `,
@@ -335,7 +321,7 @@ describe('Updates and removes current styles', () => {
 
     const App = () => {
       return (
-        <ButtonItem
+        (<ButtonItem
           /*
           TODO: (@hypermod) The usage of the 'cssFn' prop in this component could not be transformed and requires manual intervention.
           The 'cssFn' prop has been simplified so that users no longer need to merge the inherited styles with their own overrides.
@@ -349,7 +335,7 @@ describe('Updates and removes current styles', () => {
             For more info please reach out to #help-design-system-code.
             */
             cssFn={cssFunction} />
-        </ButtonItem>
+        </ButtonItem>)
       );
     };
     `,

--- a/community/@atlaskit__popper/package.json
+++ b/community/@atlaskit__popper/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__popper/src/5.0.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__popper/src/5.0.0/__tests__/transform.spec.ts
@@ -49,7 +49,7 @@ describe('@atlaskit/popper@5.0.0 transform', () => {
     export default () => {
       customModifiers = {flip: {enabled: true}};
       return (
-        <Popper modifiers={customModifiers}>
+        (<Popper modifiers={customModifiers}>
           {({
             ref,
             style,
@@ -62,7 +62,7 @@ describe('@atlaskit/popper@5.0.0 transform', () => {
               )}
             </>
           )}
-        </Popper>
+        </Popper>)
       );};
   `,
     );
@@ -198,14 +198,14 @@ describe('@atlaskit/popper@5.0.0 transform', () => {
 
       function numCommaOffset() {
         return (
-          <Popper offset={[5, 8]}>
+          (<Popper offset={[5, 8]}>
             {({ ref, style }) => (
               <div
                 ref={ref}
                 style={style}
               />
             )}
-          </Popper>
+          </Popper>)
         );
       }
       `,
@@ -236,14 +236,14 @@ describe('@atlaskit/popper@5.0.0 transform', () => {
 
     function numStringOffset() {
       return (
-        <Popper offset={[10, 0]}>
+        (<Popper offset={[10, 0]}>
           {({ ref, style }) => (
             <div
               ref={ref}
               style={style}
             />
           )}
-        </Popper>
+        </Popper>)
       );
     }
     `,
@@ -274,14 +274,14 @@ describe('@atlaskit/popper@5.0.0 transform', () => {
 
     function numOffset() {
       return (
-        <Popper offset={[10, 0]}>
+        (<Popper offset={[10, 0]}>
           {({ ref, style }) => (
             <div
               ref={ref}
               style={style}
             />
           )}
-        </Popper>
+        </Popper>)
       );
     }
     `,

--- a/community/@atlaskit__popup/package.json
+++ b/community/@atlaskit__popup/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__popup/src/1.0.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__popup/src/1.0.0/__tests__/transform.spec.ts
@@ -252,7 +252,7 @@ describe('Convert offset props', () => {
 
     function numCommaOffset() {
       return (
-        <Popup
+        (<Popup
           isOpen={isOpen}
           onClose={() => {}}
           offset={[5, 8]}
@@ -262,13 +262,13 @@ describe('Convert offset props', () => {
           trigger={triggerProps => (
             <div />
           )}
-        />
+        />)
       );
     }
 
     function numStringOffset() {
       return (
-        <Popup
+        (<Popup
           isOpen={isOpen}
           onClose={() => {}}
           offset={[10, 0]}
@@ -278,13 +278,13 @@ describe('Convert offset props', () => {
           trigger={triggerProps => (
             <div />
           )}
-        />
+        />)
       );
     }
 
     function numOffset() {
       return (
-        <Popup
+        (<Popup
           isOpen={isOpen}
           onClose={() => {}}
           offset={[10, 0]}
@@ -294,7 +294,7 @@ describe('Convert offset props', () => {
           trigger={triggerProps => (
             <div />
           )}
-        />
+        />)
       );
     }
     `,

--- a/community/@atlaskit__progress-indicator/package.json
+++ b/community/@atlaskit__progress-indicator/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__progress-indicator/src/9.0.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__progress-indicator/src/9.0.0/__tests__/transform.spec.ts
@@ -90,12 +90,12 @@ describe('@atlaskit/progress-indicator@9.0.0 transform', () => {
 
     expect(result).toMatchInlineSnapshot(`
       import { ProgressIndicator } from '@atlaskit/progress-indicator'; const
-      Component = () =>{ return (
+      Component = () =>{ return ( (
       <div>
         <ProgressIndicator />
         <ProgressIndicator x={10} />
         <ProgressIndicator></ProgressIndicator>
-      </div>); }
+      </div>) ); }
     `);
   });
 

--- a/community/@atlaskit__range/package.json
+++ b/community/@atlaskit__range/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__range/src/4.0.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__range/src/4.0.0/__tests__/transform.spec.ts
@@ -70,11 +70,11 @@ describe('@atlaskit/range@4.0.0 transform', () => {
               let ref = useRef();
 
               return (
-                <Range
+                (<Range
                   ref={newRef => {
                     ref = newRef;
                   }}
-                />
+                />)
               );
             }"
     `);

--- a/community/@atlaskit__section-message/package.json
+++ b/community/@atlaskit__section-message/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__side-navigation/package.json
+++ b/community/@atlaskit__side-navigation/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__side-navigation/src/0.8.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__side-navigation/src/0.8.0/__tests__/transform.spec.ts
@@ -48,11 +48,7 @@ describe('@atlaskit/side-navigation@0.8.0 transform', () => {
         "import { ButtonItem } from '@atlaskit/side-navigation';
 
               const App = () => {
-                return (
-                  <ButtonItem cssFn={state => {
-
-                  }} />
-                );
+                return <ButtonItem cssFn={state => ({})} />;
               }"
       `);
     });
@@ -85,9 +81,9 @@ describe('@atlaskit/side-navigation@0.8.0 transform', () => {
 
       expect(result).toMatchInlineSnapshot(`
         import { ButtonItem } from '@atlaskit/side-navigation'; const App = ()
-        => { return (
+        => { return ( (
         <div cssFn={(styles, state)=>({ ...styles, })}>
-          <ButtonItem cssFn={state=>({})} /></div>); };
+          <ButtonItem cssFn={state=>({})} /></div>) ); };
       `);
     });
 
@@ -186,7 +182,7 @@ describe('@atlaskit/side-navigation@0.8.0 transform', () => {
 
               const App = () => {
                 return (
-                  <ButtonItem
+                  (<ButtonItem
                     /*
                     TODO: (@hypermod) The usage of the 'cssFn' prop in this component could not be transformed and requires manual intervention.
                     The 'cssFn' prop has been simplified so that users no longer need to merge the inherited styles with their own overrides.
@@ -195,7 +191,7 @@ describe('@atlaskit/side-navigation@0.8.0 transform', () => {
                     cssFn={(styles, state) => ({
                       ...(state.x ? styles : {}),
                       color: 'red'
-                    })} />
+                    })} />)
                 );
               }"
       `);
@@ -371,7 +367,7 @@ describe('@atlaskit/side-navigation@0.8.0 transform', () => {
 
               const App = () => {
                 return (
-                  <ButtonItem
+                  (<ButtonItem
                     /*
                     TODO: (@hypermod) The usage of the 'cssFn' prop in this component could not be transformed and requires manual intervention.
                     The 'cssFn' prop has been simplified so that users no longer need to merge the inherited styles with their own overrides.
@@ -385,7 +381,7 @@ describe('@atlaskit/side-navigation@0.8.0 transform', () => {
                       For more info please reach out to #help-design-system-code.
                       */
                       cssFn={cssFunction} />
-                  </ButtonItem>
+                  </ButtonItem>)
                 );
               };"
       `);

--- a/community/@atlaskit__spinner/package.json
+++ b/community/@atlaskit__spinner/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__spinner/src/13.0.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__spinner/src/13.0.0/__tests__/transform.spec.ts
@@ -84,7 +84,7 @@ describe('@atlaskit/spinner@13.0.0 transform', () => {
     function App() {
       const [isCompleting] = useState(false);
       const onComplete = () => {};
-      return <Spinner delay={1000} />;
+      return (<Spinner delay={1000} />);
     }
   `,
     });
@@ -143,13 +143,13 @@ describe('@atlaskit/spinner@13.0.0 transform', () => {
     import Spinner from '@atlaskit/spinner';
     import myValue from './my-value'
 
-    return <>
+    return (<>
       <Spinner />
       <Spinner />
       <Spinner />
       <Spinner delay={151} />
       <Spinner delay={myValue} />
-    </>;
+    </>);
   `,
     });
 
@@ -177,13 +177,13 @@ describe('@atlaskit/spinner@13.0.0 transform', () => {
     import value from './value';
 
 
-    return <>
+    return (<>
       <Spinner />
       <Spinner appearance="invert" />
       <Spinner />
       <Spinner appearance="invert" />
       <Spinner appearance={value ? "invert" : "inherit"} />
-    </>;
+    </>);
   `,
     });
   });

--- a/community/@atlaskit__tag/package.json
+++ b/community/@atlaskit__tag/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__tag/src/11.0.0/__tests__/rename-remove-button-text.spec.ts
+++ b/community/@atlaskit__tag/src/11.0.0/__tests__/rename-remove-button-text.spec.ts
@@ -245,11 +245,11 @@ describe('Rename removeButtonText prop to removeButtonLabel prop', () => {
       [tags, setTags] = useState([ 'Candy canes', 'Tiramisu', 'Gummi bears',
       'Wagon Wheels', ]); const handleRemoveRequest = () => true; const handleRemoveComplete
       = (text: string) => { setTags(tags.filter(str => str !== text)); }; return
-      (
+      ( (
       <TagGroup alignment={alignment}>{tags.map(text => (
         <Tag key={text} onAfterRemoveAction={handleRemoveComplete}
         onBeforeRemoveAction={handleRemoveRequest} removeButtonLabel="Remove me"
-        text={text} />))}</TagGroup>); } export default () => (
+        text={text} />))}</TagGroup>) ); } export default () => (
       <div>
         <MyTagGroup alignment="start" />
         <MyTagGroup alignment="end" />

--- a/community/@atlaskit__textarea/package.json
+++ b/community/@atlaskit__textarea/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__textfield/package.json
+++ b/community/@atlaskit__textfield/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__textfield/src/5.0.0/__tests__/remove-prop.spec.ts
+++ b/community/@atlaskit__textfield/src/5.0.0/__tests__/remove-prop.spec.ts
@@ -47,7 +47,7 @@ describe('Remove prop', () => {
           import customeTheme from './theme';
 
           const SimpleTextfield = () => {
-            return <Textfield />;
+            return (<Textfield />);
           }"
     `);
   });
@@ -83,7 +83,7 @@ describe('Remove prop', () => {
           import customeTheme from './theme';
 
           const SimpleTextfield = () => {
-            return <TextField />;
+            return (<TextField />);
           }"
     `);
   });
@@ -121,11 +121,11 @@ describe('Remove prop', () => {
       of the \`theme\` prop. The appearance of TextField will have likely changed.
       */ import React from 'react'; import Textfield from '@atlaskit/textfield';
       import customeTheme from './theme'; const SimpleTextfield = () => { return
-      (
+      ( (
       <div>
         <Textfield />
         <Textfield />
-      </div>); }
+      </div>) ); }
     `);
   });
 
@@ -160,7 +160,7 @@ describe('Remove prop', () => {
           import customeTheme from './theme';
 
           const SimpleTextfield = () => {
-            return <Foo />;
+            return (<Foo />);
           }"
     `);
   });

--- a/community/@atlaskit__textfield/src/5.0.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__textfield/src/5.0.0/__tests__/transform.spec.ts
@@ -36,7 +36,7 @@ describe('@atlaskit/textfield@5.0.0 transform', () => {
               import React from 'react';
 
               const SimpleTextfield = () => {
-                return <Textfield />;
+                return (<Textfield />);
               }"
     `);
   });
@@ -86,7 +86,7 @@ describe('@atlaskit/textfield@5.0.0 transform', () => {
               import React from 'react';
 
               const SimpleTextfield = () => {
-                return <Textfield />;
+                return (<Textfield />);
               }"
     `);
   });

--- a/community/@atlaskit__toggle/package.json
+++ b/community/@atlaskit__toggle/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/@atlaskit__toggle/src/11.0.0/__tests__/transform.spec.ts
+++ b/community/@atlaskit__toggle/src/11.0.0/__tests__/transform.spec.ts
@@ -51,10 +51,10 @@ describe('@atlaskit/toggle@11.0.0 transform', () => {
 
     expect(result).toMatchInlineSnapshot(`
       import React from "react"; import Toggle from "@atlaskit/toggle"; () =>
-      { return (
+      { return ( (
       <div>
         <Toggle defaultChecked={true} />
-      </div>); };
+      </div>) ); };
     `);
   });
 
@@ -79,10 +79,10 @@ describe('@atlaskit/toggle@11.0.0 transform', () => {
 
     expect(result).toMatchInlineSnapshot(`
       import React from "react"; import Toggle from "@atlaskit/toggle"; () =>
-      { return (
+      { return ( (
       <div>
         <Toggle defaultChecked={false} />
-      </div>); };
+      </div>) ); };
     `);
   });
 
@@ -116,13 +116,13 @@ describe('@atlaskit/toggle@11.0.0 transform', () => {
     expect(result).toMatchInlineSnapshot(`
       import React from "react"; import Toggle from "@atlaskit/toggle"; () =>
       { const T = Toggle; const X = Toggle; const Z = Toggle; const FOO = "bar";
-      return (
+      return ( (
       <div>
         <Toggle defaultChecked={true} />
         <T defaultChecked={true} />
         <X id={true} />
         <Z defaultChecked={true} />
-      </div>); };
+      </div>) ); };
     `);
   });
 });

--- a/community/@emotion__monorepo/package.json
+++ b/community/@emotion__monorepo/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/hypermod/package.json
+++ b/community/hypermod/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/javascript/package.json
+++ b/community/javascript/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/memoize-one/package.json
+++ b/community/memoize-one/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/community/react/package.json
+++ b/community/react/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hypermod/utils": "^0.5.0",
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   },
   "devDependencies": {
     "@hypermod/cli": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jest": "^29.0.0",
     "jest-serializer-html-string": "^1.0.1",
     "jest-watch-typeahead": "^0.4.2",
-    "jscodeshift": "^0.13.1",
+    "jscodeshift": "^17.1.2",
     "junk": "^3.1.0",
     "parcel": "^2.8.3",
     "prettier": "^2.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "find-up": "5.0.0",
     "fs-extra": "^9.1.0",
     "inquirer": "^8.2.4",
-    "jscodeshift": "^0.13.1",
+    "jscodeshift": "^17.1.2",
     "live-plugin-manager": "^0.18.1",
     "lodash": "^4.17.21",
     "ora": "^5.4.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
     "@types/write-file-atomic": "^4.0.0",
     "chalk": "^4.1.0",
     "graceful-fs": "^4.2.4",
-    "jscodeshift": "^0.13.1",
+    "jscodeshift": "^17.1.2",
     "neo-async": "^2.5.0",
     "write-file-atomic": "^2.3.0"
   },

--- a/packages/initializer/src/index.ts
+++ b/packages/initializer/src/index.ts
@@ -23,7 +23,7 @@ export function getPackageJson(packageName: string, version = '0.0.0') {
       },
       dependencies: {
         '@hypermod/utils': `^${utilVersion}`,
-        jscodeshift: '^0.13.1',
+        jscodeshift: '^17.1.2',
       },
       devDependencies: {
         '@hypermod/cli': `^${cliVersion}`,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,6 +10,6 @@
     "node": ">=20.17"
   },
   "dependencies": {
-    "jscodeshift": "^0.13.1"
+    "jscodeshift": "^17.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,12 +38,26 @@
     "@babel/highlight" "^7.23.4"
     chalk "^2.4.2"
 
+"@babel/code-frame@^7.26.2":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
+  integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.25.9"
+    js-tokens "^4.0.0"
+    picocolors "^1.0.0"
+
 "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.23.3", "@babel/compat-data@^7.23.5":
   version "7.23.5"
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz"
   integrity sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.23.0":
+"@babel/compat-data@^7.26.5":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.8.tgz#821c1d35641c355284d4a870b8a4a7b0c141e367"
+  integrity sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==
+
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.0":
   version "7.23.6"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.23.6.tgz"
   integrity sha512-FxpRyGjrMJXh7X3wGLGhNDCRiwpWEF74sKjTLDJSG5Kyvow3QZaG0Adbqzi9ZrVjTWpsX+2cxWXD71NMg93kdw==
@@ -64,6 +78,27 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
+"@babel/core@^7.24.7":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.9.tgz#71838542a4b1e49dfed353d7acbc6eb89f4a76f2"
+  integrity sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==
+  dependencies:
+    "@ampproject/remapping" "^2.2.0"
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.26.9"
+    "@babel/helper-compilation-targets" "^7.26.5"
+    "@babel/helper-module-transforms" "^7.26.0"
+    "@babel/helpers" "^7.26.9"
+    "@babel/parser" "^7.26.9"
+    "@babel/template" "^7.26.9"
+    "@babel/traverse" "^7.26.9"
+    "@babel/types" "^7.26.9"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
 "@babel/generator@^7.23.6", "@babel/generator@^7.7.2":
   version "7.23.6"
   resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz"
@@ -74,12 +109,30 @@
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
+"@babel/generator@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.9.tgz#75a9482ad3d0cc7188a537aa4910bc59db67cbca"
+  integrity sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==
+  dependencies:
+    "@babel/parser" "^7.26.9"
+    "@babel/types" "^7.26.9"
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^3.0.2"
+
 "@babel/helper-annotate-as-pure@^7.22.5":
   version "7.22.5"
   resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz"
   integrity sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==
   dependencies:
     "@babel/types" "^7.22.5"
+
+"@babel/helper-annotate-as-pure@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz#d8eac4d2dc0d7b6e11fa6e535332e0d3184f06b4"
+  integrity sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==
+  dependencies:
+    "@babel/types" "^7.25.9"
 
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.22.15":
   version "7.22.15"
@@ -99,6 +152,17 @@
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
+"@babel/helper-compilation-targets@^7.26.5":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz#75d92bb8d8d51301c0d49e52a65c9a7fe94514d8"
+  integrity sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==
+  dependencies:
+    "@babel/compat-data" "^7.26.5"
+    "@babel/helper-validator-option" "^7.25.9"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
 "@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.22.15", "@babel/helper-create-class-features-plugin@^7.23.6":
   version "7.23.6"
   resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.6.tgz"
@@ -112,6 +176,19 @@
     "@babel/helper-replace-supers" "^7.22.20"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
     "@babel/helper-split-export-declaration" "^7.22.6"
+    semver "^6.3.1"
+
+"@babel/helper-create-class-features-plugin@^7.25.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.26.9.tgz#d6f83e3039547fbb39967e78043cd3c8b7820c71"
+  integrity sha512-ubbUqCofvxPRurw5L8WTsCLSkQiVpov4Qx0WMA+jUN+nXBK8ADPlJO1grkFw5CWKC5+sZSOfuGMdX1aI1iT9Sg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.25.9"
+    "@babel/helper-member-expression-to-functions" "^7.25.9"
+    "@babel/helper-optimise-call-expression" "^7.25.9"
+    "@babel/helper-replace-supers" "^7.26.5"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
+    "@babel/traverse" "^7.26.9"
     semver "^6.3.1"
 
 "@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.22.15", "@babel/helper-create-regexp-features-plugin@^7.22.5":
@@ -161,12 +238,28 @@
   dependencies:
     "@babel/types" "^7.23.0"
 
+"@babel/helper-member-expression-to-functions@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz#9dfffe46f727005a5ea29051ac835fb735e4c1a3"
+  integrity sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==
+  dependencies:
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
+
 "@babel/helper-module-imports@^7.22.15":
   version "7.22.15"
   resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz"
   integrity sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==
   dependencies:
     "@babel/types" "^7.22.15"
+
+"@babel/helper-module-imports@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz#e7f8d20602ebdbf9ebbea0a0751fb0f2a4141715"
+  integrity sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==
+  dependencies:
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
 
 "@babel/helper-module-transforms@^7.23.3":
   version "7.23.3"
@@ -179,6 +272,15 @@
     "@babel/helper-split-export-declaration" "^7.22.6"
     "@babel/helper-validator-identifier" "^7.22.20"
 
+"@babel/helper-module-transforms@^7.26.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz#8ce54ec9d592695e58d84cd884b7b5c6a2fdeeae"
+  integrity sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
+    "@babel/traverse" "^7.25.9"
+
 "@babel/helper-optimise-call-expression@^7.22.5":
   version "7.22.5"
   resolved "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz"
@@ -186,10 +288,22 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
+"@babel/helper-optimise-call-expression@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz#3324ae50bae7e2ab3c33f60c9a877b6a0146b54e"
+  integrity sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==
+  dependencies:
+    "@babel/types" "^7.25.9"
+
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.22.5"
   resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz"
   integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
+
+"@babel/helper-plugin-utils@^7.25.9", "@babel/helper-plugin-utils@^7.26.5":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz#18580d00c9934117ad719392c4f6585c9333cc35"
+  integrity sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==
 
 "@babel/helper-remap-async-to-generator@^7.22.20":
   version "7.22.20"
@@ -209,6 +323,15 @@
     "@babel/helper-member-expression-to-functions" "^7.22.15"
     "@babel/helper-optimise-call-expression" "^7.22.5"
 
+"@babel/helper-replace-supers@^7.26.5":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz#6cb04e82ae291dae8e72335dfe438b0725f14c8d"
+  integrity sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.25.9"
+    "@babel/helper-optimise-call-expression" "^7.25.9"
+    "@babel/traverse" "^7.26.5"
+
 "@babel/helper-simple-access@^7.22.5":
   version "7.22.5"
   resolved "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz"
@@ -223,6 +346,14 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
+"@babel/helper-skip-transparent-expression-wrappers@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz#0b2e1b62d560d6b1954893fd2b705dc17c91f0c9"
+  integrity sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==
+  dependencies:
+    "@babel/traverse" "^7.25.9"
+    "@babel/types" "^7.25.9"
+
 "@babel/helper-split-export-declaration@^7.22.6":
   version "7.22.6"
   resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz"
@@ -235,15 +366,30 @@
   resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz"
   integrity sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==
 
+"@babel/helper-string-parser@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
+  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
+
 "@babel/helper-validator-identifier@^7.22.20":
   version "7.22.20"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz"
   integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
 
+"@babel/helper-validator-identifier@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
+  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
+
 "@babel/helper-validator-option@^7.22.15", "@babel/helper-validator-option@^7.23.5":
   version "7.23.5"
   resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz"
   integrity sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==
+
+"@babel/helper-validator-option@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz#86e45bd8a49ab7e03f276577f96179653d41da72"
+  integrity sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==
 
 "@babel/helper-wrap-function@^7.22.20":
   version "7.22.20"
@@ -263,6 +409,14 @@
     "@babel/traverse" "^7.23.6"
     "@babel/types" "^7.23.6"
 
+"@babel/helpers@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.26.9.tgz#28f3fb45252fc88ef2dc547c8a911c255fc9fef6"
+  integrity sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==
+  dependencies:
+    "@babel/template" "^7.26.9"
+    "@babel/types" "^7.26.9"
+
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.23.4":
   version "7.23.4"
   resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz"
@@ -272,10 +426,17 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.22.15", "@babel/parser@^7.23.0", "@babel/parser@^7.23.6":
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.22.15", "@babel/parser@^7.23.0", "@babel/parser@^7.23.6":
   version "7.23.6"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz"
   integrity sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==
+
+"@babel/parser@^7.24.7", "@babel/parser@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.9.tgz#d9e78bee6dc80f9efd8f2349dcfbbcdace280fd5"
+  integrity sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==
+  dependencies:
+    "@babel/types" "^7.26.9"
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.23.3":
   version "7.23.3"
@@ -373,12 +534,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-flow@^7.23.3":
-  version "7.23.3"
-  resolved "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.23.3.tgz"
-  integrity sha512-YZiAIpkJAwQXBJLIQbRFayR5c+gJ35Vcz3bg954k7cd73zqjvhacJuL9RbrzPz8qPmZdgqP6EUKwy0PCNhaaPA==
+"@babel/plugin-syntax-flow@^7.26.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.26.0.tgz#96507595c21b45fccfc2bc758d5c45452e6164fa"
+  integrity sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-syntax-import-assertions@^7.23.3":
   version "7.23.3"
@@ -414,6 +575,13 @@
   integrity sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
+
+"@babel/plugin-syntax-jsx@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz#a34313a178ea56f1951599b929c1ceacee719290"
+  integrity sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4", "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
@@ -478,6 +646,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
+"@babel/plugin-syntax-typescript@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz#67dda2b74da43727cf21d46cf9afef23f4365399"
+  integrity sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.25.9"
+
 "@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz"
@@ -533,6 +708,14 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.22.15"
     "@babel/helper-plugin-utils" "^7.22.5"
+
+"@babel/plugin-transform-class-properties@^7.24.7":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz#a8ce84fedb9ad512549984101fa84080a9f5f51f"
+  integrity sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-transform-class-static-block@^7.23.4":
   version "7.23.4"
@@ -612,13 +795,13 @@
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
-"@babel/plugin-transform-flow-strip-types@^7.23.3":
-  version "7.23.3"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.23.3.tgz"
-  integrity sha512-26/pQTf9nQSNVJCrLB1IkHUKyPxR+lMrH2QDPG89+Znu9rAMbtrybdbWeE9bb7gzjmE5iXHEY+e0HUwM6Co93Q==
+"@babel/plugin-transform-flow-strip-types@^7.25.9":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.26.5.tgz#2904c85a814e7abb1f4850b8baf4f07d0a2389d4"
+  integrity sha512-eGK26RsbIkYUns3Y8qKl362juDDYK+wEdPGHGrhzUl6CewZFo55VZ7hg+CyMFU4dd5QQakBN86nBMpRsFpRvbQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.22.5"
-    "@babel/plugin-syntax-flow" "^7.23.3"
+    "@babel/helper-plugin-utils" "^7.26.5"
+    "@babel/plugin-syntax-flow" "^7.26.0"
 
 "@babel/plugin-transform-for-of@^7.23.6":
   version "7.23.6"
@@ -684,6 +867,14 @@
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/helper-simple-access" "^7.22.5"
 
+"@babel/plugin-transform-modules-commonjs@^7.24.7", "@babel/plugin-transform-modules-commonjs@^7.25.9":
+  version "7.26.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz#8f011d44b20d02c3de44d8850d971d8497f981fb"
+  integrity sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.26.0"
+    "@babel/helper-plugin-utils" "^7.25.9"
+
 "@babel/plugin-transform-modules-systemjs@^7.23.3":
   version "7.23.3"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.3.tgz"
@@ -724,6 +915,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+
+"@babel/plugin-transform-nullish-coalescing-operator@^7.24.7":
+  version "7.26.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz#fbf6b3c92cb509e7b319ee46e3da89c5bedd31fe"
+  integrity sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.26.5"
 
 "@babel/plugin-transform-numeric-separator@^7.23.4":
   version "7.23.4"
@@ -769,6 +967,14 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
+"@babel/plugin-transform-optional-chaining@^7.24.7":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz#e142eb899d26ef715435f201ab6e139541eee7dd"
+  integrity sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
+
 "@babel/plugin-transform-parameters@^7.23.3":
   version "7.23.3"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.23.3.tgz"
@@ -783,6 +989,14 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.22.15"
     "@babel/helper-plugin-utils" "^7.22.5"
+
+"@babel/plugin-transform-private-methods@^7.24.7":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz#847f4139263577526455d7d3223cd8bda51e3b57"
+  integrity sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-transform-private-property-in-object@^7.23.4":
   version "7.23.4"
@@ -861,6 +1075,17 @@
     "@babel/helper-create-class-features-plugin" "^7.23.6"
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/plugin-syntax-typescript" "^7.23.3"
+
+"@babel/plugin-transform-typescript@^7.25.9":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.8.tgz#2e9caa870aa102f50d7125240d9dbf91334b0950"
+  integrity sha512-bME5J9AC8ChwA7aEPJ6zym3w7aObZULHhbNLU0bKUhKsAkylkzUdq+0kdymh9rzi8nlNFl2bmldFBCKNJBUpuw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.25.9"
+    "@babel/helper-create-class-features-plugin" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.26.5"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
+    "@babel/plugin-syntax-typescript" "^7.25.9"
 
 "@babel/plugin-transform-unicode-escapes@^7.23.3":
   version "7.23.3"
@@ -979,14 +1204,14 @@
     core-js-compat "^3.31.0"
     semver "^6.3.1"
 
-"@babel/preset-flow@^7.13.13":
-  version "7.23.3"
-  resolved "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.23.3.tgz"
-  integrity sha512-7yn6hl8RIv+KNk6iIrGZ+D06VhVY35wLVf23Cz/mMu1zOr7u4MMP4j0nZ9tLf8+4ZFpnib8cFYgB/oYg9hfswA==
+"@babel/preset-flow@^7.24.7":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.25.9.tgz#ef8b5e7e3f24a42b3711e77fb14919b87dffed0a"
+  integrity sha512-EASHsAhE+SSlEzJ4bzfusnXSHiU+JfAYzj+jbw2vgQKgq5HrUr8qs+vgtiEL5dOH6sEweI+PNt2D7AqrDSHyqQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.22.5"
-    "@babel/helper-validator-option" "^7.22.15"
-    "@babel/plugin-transform-flow-strip-types" "^7.23.3"
+    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-validator-option" "^7.25.9"
+    "@babel/plugin-transform-flow-strip-types" "^7.25.9"
 
 "@babel/preset-modules@0.1.6-no-external-plugins":
   version "0.1.6-no-external-plugins"
@@ -997,7 +1222,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-typescript@^7.13.0", "@babel/preset-typescript@^7.23.0":
+"@babel/preset-typescript@^7.23.0":
   version "7.23.3"
   resolved "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.23.3.tgz"
   integrity sha512-17oIGVlqz6CchO9RFYn5U6ZpWRZIngayYCtrPRSgANSwC2V1Jb+iP74nVxzzXJte8b8BYxrL1yY96xfhTBrNNQ==
@@ -1008,10 +1233,32 @@
     "@babel/plugin-transform-modules-commonjs" "^7.23.3"
     "@babel/plugin-transform-typescript" "^7.23.3"
 
-"@babel/register@^7.13.16", "@babel/register@^7.23.0":
+"@babel/preset-typescript@^7.24.7":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.26.0.tgz#4a570f1b8d104a242d923957ffa1eaff142a106d"
+  integrity sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-validator-option" "^7.25.9"
+    "@babel/plugin-syntax-jsx" "^7.25.9"
+    "@babel/plugin-transform-modules-commonjs" "^7.25.9"
+    "@babel/plugin-transform-typescript" "^7.25.9"
+
+"@babel/register@^7.23.0":
   version "7.23.7"
   resolved "https://registry.npmjs.org/@babel/register/-/register-7.23.7.tgz"
   integrity sha512-EjJeB6+kvpk+Y5DAkEAmbOBEFkh9OASx0huoEkqYTFxAZHzOAX2Oh5uwAUuL2rUddqfM0SA+KPXV2TbzoZ2kvQ==
+  dependencies:
+    clone-deep "^4.0.1"
+    find-cache-dir "^2.0.0"
+    make-dir "^2.1.0"
+    pirates "^4.0.6"
+    source-map-support "^0.5.16"
+
+"@babel/register@^7.24.6":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.25.9.tgz#1c465acf7dc983d70ccc318eb5b887ecb04f021b"
+  integrity sha512-8D43jXtGsYmEeDvm4MWHYUpWf8iiXgWYx3fW7E7Wb7Oe6FWqJPl5K6TuFW0dOwNZzEE5rjlaSJYH9JjrUKJszA==
   dependencies:
     clone-deep "^4.0.1"
     find-cache-dir "^2.0.0"
@@ -1040,6 +1287,15 @@
     "@babel/parser" "^7.22.15"
     "@babel/types" "^7.22.15"
 
+"@babel/template@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.26.9.tgz#4577ad3ddf43d194528cff4e1fa6b232fa609bb2"
+  integrity sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/parser" "^7.26.9"
+    "@babel/types" "^7.26.9"
+
 "@babel/traverse@^7.23.6":
   version "7.23.6"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz"
@@ -1056,6 +1312,19 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
+"@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.9.tgz#4398f2394ba66d05d988b2ad13c219a2c857461a"
+  integrity sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.26.9"
+    "@babel/parser" "^7.26.9"
+    "@babel/template" "^7.26.9"
+    "@babel/types" "^7.26.9"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.6", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.23.6"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz"
@@ -1064,6 +1333,14 @@
     "@babel/helper-string-parser" "^7.23.4"
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.25.9", "@babel/types@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.9.tgz#08b43dec79ee8e682c2ac631c010bdcac54a21ce"
+  integrity sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==
+  dependencies:
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -1579,6 +1856,15 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz#4f0e06362e01362f823d348f1872b08f666d8142"
+  integrity sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==
+  dependencies:
+    "@jridgewell/set-array" "^1.2.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.1"
   resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz"
@@ -1588,6 +1874,11 @@
   version "1.1.2"
   resolved "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/set-array@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
+  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
 "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
   version "1.4.15"
@@ -1606,6 +1897,14 @@
   version "0.3.20"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz"
   integrity sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -3130,6 +3429,13 @@ ast-types@0.14.2, ast-types@^0.14.1:
   dependencies:
     tslib "^2.0.1"
 
+ast-types@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.16.1.tgz#7a9da1617c9081bc121faafe91711b4c8bb81da2"
+  integrity sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==
+  dependencies:
+    tslib "^2.0.1"
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz"
@@ -3172,11 +3478,6 @@ axios@^0.27.2:
   dependencies:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
-
-babel-core@^7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -3366,6 +3667,13 @@ braces@^3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
+
 breakword@^1.0.5:
   version "1.0.6"
   resolved "https://registry.npmjs.org/breakword/-/breakword-1.0.6.tgz"
@@ -3382,6 +3690,16 @@ browserslist@^4.22.2, browserslist@^4.6.6:
     electron-to-chromium "^1.4.601"
     node-releases "^2.0.14"
     update-browserslist-db "^1.0.13"
+
+browserslist@^4.24.0:
+  version "4.24.4"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.4.tgz#c6b2865a3f08bcb860a0e827389003b9fe686e4b"
+  integrity sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==
+  dependencies:
+    caniuse-lite "^1.0.30001688"
+    electron-to-chromium "^1.5.73"
+    node-releases "^2.0.19"
+    update-browserslist-db "^1.1.1"
 
 bs-logger@^0.2.6:
   version "0.2.6"
@@ -3480,6 +3798,11 @@ caniuse-lite@^1.0.30001565:
   version "1.0.30001570"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz"
   integrity sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==
+
+caniuse-lite@^1.0.30001688:
+  version "1.0.30001701"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz#ad9c90301f7153cf6b3314d16cc30757285bf9e7"
+  integrity sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==
 
 chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -4034,6 +4357,11 @@ electron-to-chromium@^1.4.601:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.614.tgz"
   integrity sha512-X4ze/9Sc3QWs6h92yerwqv7aB/uU8vCjZcrMjA8N9R1pjMFRe44dLsck5FzLilOYvcXuDn93B+bpGYyufc70gQ==
 
+electron-to-chromium@^1.5.73:
+  version "1.5.105"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.105.tgz#0b2396e7e1a467434cd3132950bbe53c04f74a5e"
+  integrity sha512-ccp7LocdXx3yBhwiG0qTQ7XFrK48Ua2pxIxBdJO8cbddp/MvbBtPFzvnTchtyHQTsgqqczO8cdmAIbpMa0u2+g==
+
 emittery@^0.13.1:
   version "0.13.1"
   resolved "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz"
@@ -4171,6 +4499,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escalade@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -4485,6 +4818,13 @@ fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -5846,35 +6186,39 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jscodeshift@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.13.1.tgz"
-  integrity sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==
+jscodeshift@^17.1.2:
+  version "17.1.2"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-17.1.2.tgz#d77e9d3d08fdbb1548818bc22f653aba7fc21a25"
+  integrity sha512-uime4vFOiZ1o3ICT4Sm/AbItHEVw2oCxQ3a0egYVy3JMMOctxe07H3SKL1v175YqjMt27jn1N+3+Bj9SKDNgdQ==
   dependencies:
-    "@babel/core" "^7.13.16"
-    "@babel/parser" "^7.13.16"
-    "@babel/plugin-proposal-class-properties" "^7.13.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.13.8"
-    "@babel/plugin-proposal-optional-chaining" "^7.13.12"
-    "@babel/plugin-transform-modules-commonjs" "^7.13.8"
-    "@babel/preset-flow" "^7.13.13"
-    "@babel/preset-typescript" "^7.13.0"
-    "@babel/register" "^7.13.16"
-    babel-core "^7.0.0-bridge.0"
-    chalk "^4.1.2"
+    "@babel/core" "^7.24.7"
+    "@babel/parser" "^7.24.7"
+    "@babel/plugin-transform-class-properties" "^7.24.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.24.7"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.24.7"
+    "@babel/plugin-transform-optional-chaining" "^7.24.7"
+    "@babel/plugin-transform-private-methods" "^7.24.7"
+    "@babel/preset-flow" "^7.24.7"
+    "@babel/preset-typescript" "^7.24.7"
+    "@babel/register" "^7.24.6"
     flow-parser "0.*"
     graceful-fs "^4.2.4"
-    micromatch "^3.1.10"
+    micromatch "^4.0.7"
     neo-async "^2.5.0"
-    node-dir "^0.1.17"
-    recast "^0.20.4"
-    temp "^0.8.4"
-    write-file-atomic "^2.3.0"
+    picocolors "^1.0.1"
+    recast "^0.23.9"
+    tmp "^0.2.3"
+    write-file-atomic "^5.0.1"
 
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+jsesc@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
+  integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -6355,6 +6699,14 @@ micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+micromatch@^4.0.7:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
@@ -6382,7 +6734,7 @@ min-indent@^1.0.0:
   resolved "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -6543,13 +6895,6 @@ node-addon-api@^7.0.0:
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz"
   integrity sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==
 
-node-dir@^0.1.17:
-  version "0.1.17"
-  resolved "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz"
-  integrity sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==
-  dependencies:
-    minimatch "^3.0.2"
-
 node-fetch@^2.6.6:
   version "2.7.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
@@ -6578,6 +6923,11 @@ node-releases@^2.0.14:
   version "2.0.14"
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
+
+node-releases@^2.0.19:
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
+  integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -6866,6 +7216,11 @@ picocolors@^1.0.0:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
+picocolors@^1.0.1, picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
@@ -7115,6 +7470,17 @@ recast@^0.20.3, recast@^0.20.4:
     ast-types "0.14.2"
     esprima "~4.0.0"
     source-map "~0.6.1"
+    tslib "^2.0.1"
+
+recast@^0.23.9:
+  version "0.23.9"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.23.9.tgz#587c5d3a77c2cfcb0c18ccce6da4361528c2587b"
+  integrity sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==
+  dependencies:
+    ast-types "^0.16.1"
+    esprima "~4.0.0"
+    source-map "~0.6.1"
+    tiny-invariant "^1.3.3"
     tslib "^2.0.1"
 
 redent@^3.0.0:
@@ -7493,6 +7859,11 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -7917,12 +8288,22 @@ timsort@^0.3.0:
   resolved "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz"
   integrity sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==
 
+tiny-invariant@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
+  integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
+  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -8216,6 +8597,14 @@ update-browserslist-db@^1.0.13:
     escalade "^3.1.1"
     picocolors "^1.0.0"
 
+update-browserslist-db@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz#97e9c96ab0ae7bcac08e9ae5151d26e6bc6b5580"
+  integrity sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==
+  dependencies:
+    escalade "^3.2.0"
+    picocolors "^1.1.1"
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
@@ -8409,6 +8798,14 @@ write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+write-file-atomic@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"
+  integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^4.0.1"
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
Closes: #242 

Bumps jscodeshift globally to the latest version.

Previously this was pinned to a lower version because of a JSX formatting bug with recast (which is why all of the tests failed) but, we are going to move forward in the meantime in hope that the maintainers patch it.

https://github.com/benjamn/recast/pull/1406
